### PR TITLE
8.x-4.x - Update Fastly module to support Purge module

### DIFF
--- a/config/schema/fastly.schema.yml
+++ b/config/schema/fastly.schema.yml
@@ -20,6 +20,3 @@ fastly.settings:
     stale_if_error_value:
       type: integer
       label: 'Fastly stale if error value'
-    valid_purge_credentials:
-      type: boolean
-      label: 'Purge credentials are valid'

--- a/config/schema/fastly.schema.yml
+++ b/config/schema/fastly.schema.yml
@@ -20,3 +20,6 @@ fastly.settings:
     stale_if_error_value:
       type: integer
       label: 'Fastly stale if error value'
+    valid_purge_credentials:
+      type: boolean
+      label: 'Purge credentials are valid'

--- a/fastly.drush.inc
+++ b/fastly.drush.inc
@@ -13,7 +13,7 @@ function fastly_drush_command() {
   $items['fastly-purge-all'] = [
     'description' => 'Purge all fastly caches.',
     'arguments' => [
-      'tags' => 'An comma-separated list of cache tags or keys to purge, or leave empty to purge all.',
+      'tags' => 'An comma-separated list of cache tags or hashes to purge, or leave empty to purge all.',
     ],
     'drupal dependencies' => ['fastly'],
     'aliases' => ['fastly:purge'],
@@ -39,7 +39,6 @@ function drush_fastly_purge_all($tags = '') {
   }
   else {
     $cache_tags = explode(',', $tags);
-    // @TODO: Should also purge hashes.
     $api->purgeKeys($cache_tags);
   }
 }

--- a/fastly.drush.inc
+++ b/fastly.drush.inc
@@ -13,10 +13,18 @@ function fastly_drush_command() {
   $items['fastly-purge-all'] = [
     'description' => 'Purge all fastly caches.',
     'arguments' => [
-      'tags' => 'An comma-separated list of cache tags to purge, or leave empty to purge all.',
+      'tags' => 'An comma-separated list of cache tags or keys to purge, or leave empty to purge all.',
     ],
     'drupal dependencies' => ['fastly'],
     'aliases' => ['fastly:purge'],
+  ];
+  $items['fastly-purge-url'] = [
+    'description' => 'Purge URL from fastly caches.',
+    'arguments' => [
+      'path' => 'A full URL to purge from Fastly',
+    ],
+    'drupal dependencies' => ['fastly'],
+    'aliases' => ['fastly:purge-url'],
   ];
   return $items;
 }
@@ -31,10 +39,17 @@ function drush_fastly_purge_all($tags = '') {
   }
   else {
     $cache_tags = explode(',', $tags);
-    if (!empty($cache_tags)) {
-      foreach ($cache_tags as $tag) {
-        $api->purgeKey(trim($tag));
-      }
-    }
+    // @TODO: Should also purge hashes.
+    $api->purgeKeys($cache_tags);
+  }
+}
+
+/**
+ * Call back function to purge a single URL at Fastly from drush.
+ */
+function drush_fastly_purge_path($url = '') {
+  $api = Drupal::service('fastly.api');
+  if (!empty($url)) {
+    $api->purgeUrl($url);
   }
 }

--- a/fastly.install
+++ b/fastly.install
@@ -18,7 +18,7 @@ function fastly_requirements($phase) {
     $valid_purge_credentials = $config->get('valid_purge_credentials') === TRUE;
 
     if (!$valid_purge_credentials) {
-      $link_to_settings = Url::fromRoute('fastly.admin_settings_form')->toString();
+      $link_to_settings = Url::fromRoute('fastly.settings')->toString();
       $message = t('Missing valid purge credentials for Fastly. Please go <a href="@link_to_settings">here</a> to set.', ['@link_to_settings' => $link_to_settings]);
 
       $requirements['fastly'] = [

--- a/fastly.install
+++ b/fastly.install
@@ -14,10 +14,14 @@ function fastly_requirements($phase) {
   $requirements = [];
 
   if ($phase == 'runtime') {
-    $config = \Drupal::config('fastly.settings');
-    $valid_purge_credentials = $config->get('valid_purge_credentials') === TRUE;
 
-    if (!$valid_purge_credentials) {
+    // Check API token to be sure it has not been removed from Fastly or expired.
+    $config = \Drupal::config('fastly.settings');
+    $state = \Drupal::service('fastly.state');
+    $purge_credentials_state = (!empty($config->get('api_key'))) ? $state->validatePurgeCredentials($config->get('api_key')) : FALSE;
+    $state->setPurgeCredentialsState($purge_credentials_state);
+
+    if (!$purge_credentials_state) {
       $link_to_settings = Url::fromRoute('fastly.settings')->toString();
       $message = t('Missing valid purge credentials for Fastly. Please go <a href="@link_to_settings">here</a> to set.', ['@link_to_settings' => $link_to_settings]);
 
@@ -29,17 +33,4 @@ function fastly_requirements($phase) {
     }
   }
   return $requirements;
-}
-
-/**
- * Update Fastly config to add valid_purge_credentials.
- */
-function fastly_update_8001(&$sandbox) {
-  $fastly_api = \Drupal::service('fastly.api');
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('fastly.settings');
-  $fastly_api_key = $config->get('api_key');
-  $valid_purge_credentials = (!empty($fastly_api_key)) ? $fastly_api->validateApiKey($fastly_api_key) : FALSE;
-  $config->set('valid_purge_credentials', $valid_purge_credentials);
-  $config->save(TRUE);
 }

--- a/fastly.install
+++ b/fastly.install
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall functions for the Fastly module.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_requirements().
+ */
+function fastly_requirements($phase) {
+  $requirements = [];
+
+  if ($phase == 'runtime') {
+    $config = \Drupal::config('fastly.settings');
+    $valid_purge_credentials = $config->get('valid_purge_credentials') === TRUE;
+
+    if (!$valid_purge_credentials) {
+      $link_to_settings = Url::fromRoute('fastly.admin_settings_form')->toString();
+      $message = t('Missing valid purge credentials for Fastly. Please go <a href="@link_to_settings">here</a> to set.', ['@link_to_settings' => $link_to_settings]);
+
+      $requirements['fastly'] = [
+        'title' => t('Fastly - Credentials'),
+        'severity' => REQUIREMENT_ERROR,
+        'description' => $message,
+      ];
+    }
+  }
+  return $requirements;
+}
+
+/**
+ * Update Fastly config to add valid_purge_credentials.
+ */
+function fastly_update_8001(&$sandbox) {
+  $fastly_api = \Drupal::service('fastly.api');
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('fastly.settings');
+  $fastly_api_key = $config->get('api_key');
+  $valid_purge_credentials = (!empty($fastly_api_key)) ? $fastly_api->validateApiKey($fastly_api_key) : FALSE;
+  $config->set('valid_purge_credentials', $valid_purge_credentials);
+  $config->save(TRUE);
+}

--- a/fastly.install
+++ b/fastly.install
@@ -16,9 +16,10 @@ function fastly_requirements($phase) {
   if ($phase == 'runtime') {
 
     // Check API token to be sure it has not been removed from Fastly or expired.
+    $api = \Drupal::service('fastly.api');
     $config = \Drupal::config('fastly.settings');
     $state = \Drupal::service('fastly.state');
-    $purge_credentials_state = (!empty($config->get('api_key'))) ? $state->validatePurgeCredentials($config->get('api_key')) : FALSE;
+    $purge_credentials_state = (!empty($config->get('api_key'))) ? $api->validatePurgeCredentials($config->get('api_key')) : FALSE;
     $state->setPurgeCredentialsState($purge_credentials_state);
 
     if (!$purge_credentials_state) {

--- a/fastly.module
+++ b/fastly.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains fastly.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function fastly_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the Fastly module.
+    case 'help.page.fastly':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Fastly CDN integration.') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/fastly.services.yml
+++ b/fastly.services.yml
@@ -20,6 +20,11 @@ services:
     arguments: ['@logger.channel.fastly', '@config.factory']
     tags:
       - { name: event_subscriber }
+  fastly.state:
+    class: Drupal\fastly\State
+    arguments: ['@config.factory', '@state', '@fastly.api']
+    tags:
+      - { name: fastly}
   logger.channel.fastly:
     parent: logger.channel_base
     arguments: ['fastly']

--- a/fastly.services.yml
+++ b/fastly.services.yml
@@ -4,7 +4,7 @@ parameters:
 services:
   fastly.api:
     class: Drupal\fastly\Api
-    arguments: ['@config.factory', '%fastly.host%', '@http_client', '@logger.channel.fastly']
+    arguments: ['@config.factory', '%fastly.host%', '@http_client', '@logger.channel.fastly', '@fastly.state']
   fastly.cache_tags.invalidator:
     class: Drupal\fastly\CacheTagsInvalidator
     arguments: ['@fastly.api']
@@ -22,7 +22,7 @@ services:
       - { name: event_subscriber }
   fastly.state:
     class: Drupal\fastly\State
-    arguments: ['@config.factory', '@state', '@fastly.api']
+    arguments: ['@state']
     tags:
       - { name: fastly}
   logger.channel.fastly:

--- a/modules/fastlypurger/fastlypurger.info.yml
+++ b/modules/fastlypurger/fastlypurger.info.yml
@@ -1,6 +1,6 @@
 name: Fastly Purger
 type: module
-description: Fastly CDN integration.
+description: Integration with the Fastly service and the Purge module.
 core: 8.x
 package: Purge - reverse proxies & CDNs
 configure: fastly.admin_settings_form

--- a/modules/fastlypurger/fastlypurger.info.yml
+++ b/modules/fastlypurger/fastlypurger.info.yml
@@ -1,0 +1,9 @@
+name: Fastly Purger
+type: module
+description: Fastly CDN integration.
+core: 8.x
+package: Purge - reverse proxies & CDNs
+configure: fastly.admin_settings_form
+dependencies:
+  - fastly
+  - purge

--- a/modules/fastlypurger/src/FastlypurgerServiceProvider.php
+++ b/modules/fastlypurger/src/FastlypurgerServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\fastlypurger;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Modifies the Fastly fastly.cache_tags.invalidator service.
+ */
+class FastlypurgerServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $definition = $container->getDefinition('fastly.cache_tags.invalidator');
+    $definition->clearTag('cache_tags_invalidator');
+    // $definition->setClass('Drupal\fastlypurger\CacheTagsInvalidator');.
+  }
+
+}

--- a/modules/fastlypurger/src/FastlypurgerServiceProvider.php
+++ b/modules/fastlypurger/src/FastlypurgerServiceProvider.php
@@ -16,7 +16,6 @@ class FastlypurgerServiceProvider extends ServiceProviderBase {
   public function alter(ContainerBuilder $container) {
     $definition = $container->getDefinition('fastly.cache_tags.invalidator');
     $definition->clearTag('cache_tags_invalidator');
-    // $definition->setClass('Drupal\fastlypurger\CacheTagsInvalidator');.
   }
 
 }

--- a/modules/fastlypurger/src/Plugin/Purge/DiagnosticCheck/CredentialCheck.php
+++ b/modules/fastlypurger/src/Plugin/Purge/DiagnosticCheck/CredentialCheck.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\fastlypurger\Plugin\Purge\DiagnosticCheck;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\purge\Plugin\Purge\DiagnosticCheck\DiagnosticCheckBase;
+use Drupal\purge\Plugin\Purge\DiagnosticCheck\DiagnosticCheckInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Checks if valid Api credentials have been entered for Fastly.
+ *
+ * @PurgeDiagnosticCheck(
+ *   id = "fastly_creds",
+ *   title = @Translation("Fastly - Credentials"),
+ *   description = @Translation("Checks to see if the supplied account credentials for Fastly are valid."),
+ *   dependent_queue_plugins = {},
+ *   dependent_purger_plugins = {"fastly"}
+ * )
+ */
+class CredentialCheck extends DiagnosticCheckBase implements DiagnosticCheckInterface {
+  /**
+   * The settings configuration.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * Constructs a CredentialCheck object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   The factory for configuration objects.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->config = $config->get('fastly.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function run() {
+    $has_valid_credentials = $this->config->get('valid_purge_credentials');
+
+    if (!$has_valid_credentials) {
+      $this->recommendation = $this->t("Invalid Api credentials. Make sure the token you are trying has at least global:read, purge_select, and purge_all scopes.");
+      return SELF::SEVERITY_ERROR;
+    }
+
+    $this->recommendation = $this->t('Valid Api credentials detected.');
+    return SELF::SEVERITY_OK;
+  }
+
+}

--- a/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
+++ b/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
@@ -28,7 +28,7 @@ class FastlyPurger extends PurgerBase implements PurgerInterface {
    *
    * @var \Drupal\fastly\Api
    */
-  protected $fastlyApi;
+  protected $api;
 
   /**
    * The settings configuration.
@@ -61,17 +61,17 @@ class FastlyPurger extends PurgerBase implements PurgerInterface {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config
    *   The factory for configuration objects.
-   * @param \Drupal\fastly\Api $fastlyApi
+   * @param \Drupal\fastly\Api $api
    *   Fastly API for Drupal.
    *
    * @throws \LogicException
    *   Thrown if $configuration['id'] is missing, see Purger\Service::createId.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config, Api $fastlyApi) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config, Api $api) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->config = $config->get('fastly.settings');
-    $this->fastlyApi = $fastlyApi;
+    $this->api = $api;
   }
 
   /**
@@ -193,16 +193,16 @@ class FastlyPurger extends PurgerBase implements PurgerInterface {
   protected function invalidateItems($type = NULL, array $invalidates = []) {
     try {
       if ($type === 'tags') {
-        $purged = $this->fastlyApi->purgeKeys($invalidates);
+        $purged = $this->api->purgeKeys($invalidates);
       }
       elseif ($type === 'urls') {
         // $invalidates should be an array with one URL.
         foreach ($invalidates as $invalidate) {
-          $purged = $this->fastlyApi->purgeUrl($invalidate);
+          $purged = $this->api->purgeUrl($invalidate);
         }
       }
       else {
-        $purged = $this->fastlyApi->purgeAll();
+        $purged = $this->api->purgeAll();
       }
       if ($purged) {
         return InvalidationInterface::SUCCEEDED;

--- a/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
+++ b/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Drupal\fastlypurger\Plugin\Purge\Purger;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\fastly\Api;
+use Drupal\fastly\EventSubscriber\SurrogateKeyGenerator;
+use Drupal\purge\Plugin\Purge\Purger\PurgerBase;
+use Drupal\purge\Plugin\Purge\Purger\PurgerInterface;
+use Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Fastly purger.
+ *
+ * @PurgePurger(
+ *   id = "fastly",
+ *   label = @Translation("Fastly"),
+ *   description = @Translation("Purger for Fastly."),
+ *   types = {"tag", "url", "everything"},
+ *   multi_instance = FALSE,
+ * )
+ */
+class FastlyPurger extends PurgerBase implements PurgerInterface {
+
+  /**
+   * Fastly API.
+   *
+   * @var \Drupal\fastly\Api
+   */
+  protected $fastlyApi;
+
+  /**
+   * The settings configuration.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('fastly.api')
+    );
+  }
+
+  /**
+   * Constructs a \Drupal\Component\Plugin\FastlyPurger.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   The factory for configuration objects.
+   * @param \Drupal\fastly\Api $fastlyApi
+   *   Fastly API for Drupal.
+   *
+   * @throws \LogicException
+   *   Thrown if $configuration['id'] is missing, see Purger\Service::createId.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config, Api $fastlyApi) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->config = $config->get('fastly.settings');
+    $this->fastlyApi = $fastlyApi;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasRuntimeMeasurement() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function routeTypeToMethod($type) {
+    $methods = [
+      'tag'  => 'invalidateTags',
+      'url'  => 'invalidateUrls',
+      'everything' => 'invalidateAll',
+    ];
+    return isset($methods[$type]) ? $methods[$type] : 'invalidate';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidate(array $invalidations) {
+    throw new \LogicException('This should not execute.');
+  }
+
+  /**
+   * Invalidate a set of urls.
+   *
+   * @param \Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface[] $invalidations
+   *   The invalidator instance.
+   *
+   * @throws \Exception
+   */
+  public function invalidateUrls(array $invalidations) {
+    $urls = [];
+    // Set all invalidation states to PROCESSING before kick off purging.
+    /* @var \Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface $invalidation */
+    foreach ($invalidations as $invalidation) {
+      $invalidation->setState(InvalidationInterface::PROCESSING);
+      $urls[] = $invalidation->getExpression();
+    }
+
+    if (empty($urls)) {
+      foreach ($invalidations as $invalidation) {
+        $invalidation->setState(InvalidationInterface::FAILED);
+        throw new \Exception('No url found to purge');
+      }
+    }
+
+    // Fastly only allows purging of a single URL per request.
+    $urls_each = array_chunk($urls, 1);
+    foreach ($urls_each as $url) {
+      // Invalidate and update the item state.
+      $invalidation_state = $this->invalidateItems('urls', $url);
+    }
+    $this->updateState($invalidations, $invalidation_state);
+  }
+
+  /**
+   * Invalidate a set of tags.
+   *
+   * @param \Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface[] $invalidations
+   *   The invalidator instance.
+   *
+   * @throws \Exception
+   */
+  public function invalidateTags(array $invalidations) {
+    $tags = [];
+    // Set all invalidation states to PROCESSING before kick off purging.
+    /* @var \Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface $invalidation */
+    foreach ($invalidations as $invalidation) {
+      $invalidation->setState(InvalidationInterface::PROCESSING);
+      $tags[] = $invalidation->getExpression();
+    }
+
+    if (empty($tags)) {
+      foreach ($invalidations as $invalidation) {
+        $invalidation->setState(InvalidationInterface::FAILED);
+        throw new \Exception('No tag found to purge');
+      }
+    }
+
+    // Invalidate and update the item state.
+    // @TODO: Does Fastly have a limit per purge we need to consider (32k)?
+    // Also invalidate the cache tags as hashes, to automatically also work for
+    // responses that exceed the 16 KB header limit.
+    $hashes = array_merge($tags, SurrogateKeyGenerator::cacheTagsToHashes($tags));
+    $invalidation_state = $this->invalidateItems('tags', $hashes);
+    $this->updateState($invalidations, $invalidation_state);
+  }
+
+  /**
+   * Invalidate everything.
+   *
+   * @param \Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface[] $invalidations
+   *   The invalidator instance.
+   */
+  public function invalidateAll(array $invalidations) {
+    $this->updateState($invalidations, InvalidationInterface::PROCESSING);
+    // Invalidate and update the item state.
+    $invalidation_state = $this->invalidateItems();
+    $this->updateState($invalidations, $invalidation_state);
+  }
+
+  /**
+   * Invalidate Fastly cache.
+   *
+   * @param mixed $type
+   *   Type to purge like tags/url. If null, will purge everything.
+   * @param string[] $invalidates
+   *   A list of items to invalidate.
+   *
+   * @return int
+   *   Returns invalidate items.
+   */
+  protected function invalidateItems($type = NULL, array $invalidates = []) {
+    try {
+      if ($type === 'tags') {
+        $purged = $this->fastlyApi->purgeKeys($invalidates);
+      }
+      elseif ($type === 'urls') {
+        // $invalidates should be an array with one URL.
+        foreach ($invalidates as $invalidate) {
+          $purged = $this->fastlyApi->purgeUrl($invalidate);
+        }
+      }
+      else {
+        $purged = $this->fastlyApi->purgeAll();
+      }
+      if ($purged) {
+        return InvalidationInterface::SUCCEEDED;
+      }
+      return InvalidationInterface::FAILED;
+    }
+    catch (RequestException $e) {
+      return InvalidationInterface::FAILED;
+    }
+    finally {
+      // @TODO: Check/increment API limits - https://docs.fastly.com/api/#rate-limiting.
+    }
+  }
+
+  /**
+   * Update the invalidation state of items.
+   *
+   * @param \Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface[] $invalidations
+   *   The invalidator instance.
+   * @param int $invalidation_state
+   *   The invalidation state.
+   */
+  protected function updateState(array $invalidations, $invalidation_state) {
+    // Update the state.
+    foreach ($invalidations as $invalidation) {
+      $invalidation->setState($invalidation_state);
+    }
+  }
+
+}

--- a/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
+++ b/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
@@ -209,7 +209,7 @@ class FastlyPurger extends PurgerBase implements PurgerInterface {
       }
       return InvalidationInterface::FAILED;
     }
-    catch (RequestException $e) {
+    catch (\Exception $e) {
       return InvalidationInterface::FAILED;
     }
     finally {

--- a/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
+++ b/modules/fastlypurger/src/Plugin/Purge/Purger/FastlyPurger.php
@@ -161,7 +161,7 @@ class FastlyPurger extends PurgerBase implements PurgerInterface {
     // @TODO: Does Fastly have a limit per purge we need to consider (32k)?
     // Also invalidate the cache tags as hashes, to automatically also work for
     // responses that exceed the 16 KB header limit.
-    $hashes = array_merge($tags, SurrogateKeyGenerator::cacheTagsToHashes($tags));
+    $hashes = SurrogateKeyGenerator::cacheTagsToHashes($tags);
     $invalidation_state = $this->invalidateItems('tags', $hashes);
     $this->updateState($invalidations, $invalidation_state);
   }

--- a/src/Api.php
+++ b/src/Api.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Fastly;
+namespace Drupal\fastly;
 
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Config\ConfigFactoryInterface;

--- a/src/CacheTagsInvalidator.php
+++ b/src/CacheTagsInvalidator.php
@@ -38,12 +38,10 @@ class CacheTagsInvalidator implements CacheTagsInvalidatorInterface {
       return;
     }
 
-    $this->fastlyApi->purgeKeys($tags);
-
     // Also invalidate the cache tags as hashes, to automatically also work for
     // responses that exceed the 16 KB header limit.
-    $hashes = SurrogateKeyGenerator::cacheTagsToHashes($tags);
-    $this->fastlyApi->purgeKeys($hashes);
+    $all_tags_and_hashes = array_merge($tags, SurrogateKeyGenerator::cacheTagsToHashes($tags));
+    $this->fastlyApi->purgeKeys($all_tags_and_hashes);
   }
 
 }

--- a/src/CacheTagsInvalidator.php
+++ b/src/CacheTagsInvalidator.php
@@ -13,14 +13,14 @@ class CacheTagsInvalidator implements CacheTagsInvalidatorInterface {
   /**
    * The Fastly API.
    *
-   * @var \Drupal\Fastly\Api
+   * @var \Drupal\fastly\Api
    */
   protected $fastlyApi;
 
   /**
    * Constructs a CacheTagsInvalidator object.
    *
-   * @param \Drupal\Fastly\Api $fastly_api
+   * @param \Drupal\fastly\Api $fastly_api
    *   The Fastly API.
    */
   public function __construct(Api $fastly_api) {

--- a/src/CacheTagsInvalidator.php
+++ b/src/CacheTagsInvalidator.php
@@ -40,7 +40,7 @@ class CacheTagsInvalidator implements CacheTagsInvalidatorInterface {
 
     // Also invalidate the cache tags as hashes, to automatically also work for
     // responses that exceed the 16 KB header limit.
-    $all_tags_and_hashes = array_merge($tags, SurrogateKeyGenerator::cacheTagsToHashes($tags));
+    $all_tags_and_hashes = SurrogateKeyGenerator::cacheTagsToHashes($tags);
     $this->fastlyApi->purgeKeys($all_tags_and_hashes);
   }
 

--- a/src/CacheTagsInvalidator.php
+++ b/src/CacheTagsInvalidator.php
@@ -15,16 +15,16 @@ class CacheTagsInvalidator implements CacheTagsInvalidatorInterface {
    *
    * @var \Drupal\fastly\Api
    */
-  protected $fastlyApi;
+  protected $api;
 
   /**
    * Constructs a CacheTagsInvalidator object.
    *
-   * @param \Drupal\fastly\Api $fastly_api
+   * @param \Drupal\fastly\Api $api
    *   The Fastly API.
    */
-  public function __construct(Api $fastly_api) {
-    $this->fastlyApi = $fastly_api;
+  public function __construct(Api $api) {
+    $this->api = $api;
   }
 
   /**
@@ -34,14 +34,14 @@ class CacheTagsInvalidator implements CacheTagsInvalidatorInterface {
     // When either an extension (module/theme) is (un)installed, purge
     // everything.
     if (in_array('config:core.extension', $tags)) {
-      $this->fastlyApi->purgeAll();
+      $this->api->purgeAll();
       return;
     }
 
     // Also invalidate the cache tags as hashes, to automatically also work for
     // responses that exceed the 16 KB header limit.
     $all_tags_and_hashes = SurrogateKeyGenerator::cacheTagsToHashes($tags);
-    $this->fastlyApi->purgeKeys($all_tags_and_hashes);
+    $this->api->purgeKeys($all_tags_and_hashes);
   }
 
 }

--- a/src/EventSubscriber/SurrogateKeyGenerator.php
+++ b/src/EventSubscriber/SurrogateKeyGenerator.php
@@ -46,12 +46,10 @@ class SurrogateKeyGenerator implements EventSubscriberInterface {
 
     if (method_exists($response, 'getCacheableMetadata')) {
       $surrogate_key_header_value = implode(' ', $response->getCacheableMetadata()->getCacheTags());
-      if (strlen($surrogate_key_header_value) > 16384) {
-        $this->logger->notice('X-Drupal-Cache-Tags header size exceeded the 16 KB limit that Fastly supports; replaced the cache tags with hashed equivalents.');
-        $cache_tags = explode(' ', $surrogate_key_header_value);
-        $hashes = static::cacheTagsToHashes($cache_tags);
-        $surrogate_key_header_value = implode(' ', $hashes);
-      }
+
+      $cache_tags = explode(' ', $surrogate_key_header_value);
+      $hashes = static::cacheTagsToHashes($cache_tags);
+      $surrogate_key_header_value = implode(' ', $hashes);
 
       $response->headers->set('Surrogate-Key', $surrogate_key_header_value);
     }

--- a/src/Form/FastlySettingsForm.php
+++ b/src/Form/FastlySettingsForm.php
@@ -25,7 +25,7 @@ class FastlySettingsForm extends ConfigFormBase {
    *
    * @var \Drupal\fastly\Api
    */
-  protected $fastlyApi;
+  protected $api;
 
   /**
    * @var \Drupal\fastly\State
@@ -37,14 +37,14 @@ class FastlySettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
-   * @param \Drupal\fastly\Api $fastlyApi
+   * @param \Drupal\fastly\Api $api
    *   Fastly API for Drupal.
    * @param \Drupal\fastly\State $state
    *   Fastly state service for Drupal.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, Api $fastlyApi, State $state) {
+  public function __construct(ConfigFactoryInterface $config_factory, Api $api, State $state) {
     parent::__construct($config_factory);
-    $this->fastlyApi = $fastlyApi;
+    $this->api = $api;
     $this->state = $state;
   }
 
@@ -180,7 +180,7 @@ class FastlySettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    if (!$this->state->validatePurgeCredentials($form_state->getValue('api_key'))) {
+    if (!$this->api->validatePurgeCredentials($form_state->getValue('api_key'))) {
       $form_state->setErrorByName('api_key', $this->t('Invalid API token. Make sure the token you are trying has at least <em>global:read</em>, <em>purge_all</em>, and <em>purge_all</em> scopes.'));
     }
   }
@@ -215,11 +215,11 @@ class FastlySettingsForm extends ConfigFormBase {
    *   Array of service ids mapped to service names.
    */
   protected function getServiceOptions($api_key) {
-    if (empty($this->fastlyApi->apiKey)) {
+    if (empty($this->api->apiKey)) {
       return [];
     }
 
-    $services = $this->fastlyApi->getServices();
+    $services = $this->api->getServices();
     $service_options = [];
     foreach ($services as $service) {
       $service_options[$service->id] = $service->name;

--- a/src/Form/FastlySettingsForm.php
+++ b/src/Form/FastlySettingsForm.php
@@ -60,7 +60,7 @@ class FastlySettingsForm extends ConfigFormBase {
       '#title' => $this->t('API key'),
       '#default_value' => $api_key,
       '#required' => TRUE,
-      '#description' => t("You can find your API key on the Fastly Account Settings page. If you don't have an account yet, please visit <a href='https://www.fastly.com/signup'>https://www.fastly.com/signup</a> on Fastly."),
+      '#description' => t("You can find your personal API tokens on your Fastly Account Settings page. See <a href='https://docs.fastly.com/guides/account-management-and-security/using-api-tokens'>using API tokens</a> for more information. It is recommended that the token you provide has at least <em>global:read</em>, <em>purge_select</em>, and <em>purge_all</em> scopes. If you don't have an account yet, please visit <a href='https://www.fastly.com/signup'>https://www.fastly.com/signup</a> on Fastly."),
       // Update the listed services whenever the API key is modified.
       '#ajax' => [
         'callback' => '::updateServices',
@@ -156,7 +156,7 @@ class FastlySettingsForm extends ConfigFormBase {
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     if (!$this->isValidApiKey($form_state->getValue('api_key'))) {
-      $form_state->setErrorByName('api_key', $this->t('Invalid API key.'));
+      $form_state->setErrorByName('api_key', $this->t('Invalid API token. Make sure the token you are trying has at least <em>global:read</em>, <em>purge_all</em>, and <em>purge_all</em> scopes.'));
     }
   }
 
@@ -171,6 +171,7 @@ class FastlySettingsForm extends ConfigFormBase {
       ->set('stale_while_revalidate_value', $form_state->getValue('stale_while_revalidate_value'))
       ->set('stale_if_error', $form_state->getValue('stale_if_error'))
       ->set('stale_if_error_value', $form_state->getValue('stale_if_error_value'))
+      ->set('valid_purge_credentials', TRUE)
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Form/FastlySettingsForm.php
+++ b/src/Form/FastlySettingsForm.php
@@ -5,6 +5,8 @@ namespace Drupal\fastly\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\fastly\Api;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Defines a form to configure module settings.
@@ -20,7 +22,7 @@ class FastlySettingsForm extends ConfigFormBase {
   /**
    * The Fastly API.
    *
-   * @var \Drupal\Fastly\Api
+   * @var \Drupal\fastly\Api
    */
   protected $fastlyApi;
 
@@ -29,9 +31,22 @@ class FastlySettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
+   * @param \Drupal\fastly\Api $fastlyApi
+   *   Fastly API for Drupal.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->fastlyApi = \Drupal::service('fastly.api');
+  public function __construct(ConfigFactoryInterface $config_factory, Api $fastlyApi) {
+    parent::__construct($config_factory);
+    $this->fastlyApi = $fastlyApi;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('fastly.api'),
+    );
   }
 
   /**

--- a/src/State.php
+++ b/src/State.php
@@ -4,7 +4,6 @@ namespace Drupal\fastly;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\State\StateInterface;
-use Drupal\fastly\Api;
 
 /**
  * Tracks validity of credentials associated with Fastly Api.
@@ -19,7 +18,7 @@ class State {
   protected $config;
 
   /**
-   * @var StateInterface
+   * @var \Drupal\Core\State\StateInterface
    */
   protected $state;
 

--- a/src/State.php
+++ b/src/State.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\fastly;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\fastly\Api;
+
+/**
+ * Tracks validity of credentials associated with Fastly Api.
+ */
+class State {
+
+  const VALID_PURGE_CREDENTIALS = 'fastly.state.valid_purge_credentials';
+
+  /**
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * @var StateInterface
+   */
+  protected $state;
+
+  /**
+   * @var \Drupal\fastly\Api
+   */
+  protected $fastlyApi;
+
+  /**
+   * @var bool
+   */
+  protected $validPurgeCredentials;
+
+  /**
+   * ValidateCredentials constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   Fastly config object.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The drupal state service.
+   * @param \Drupal\fastly\Api $fastlyApi
+   *   Fastly API for Drupal.
+   */
+  public function __construct(ConfigFactoryInterface $config, StateInterface $state, Api $fastlyApi) {
+    $this->config = $config->get('fastly.settings');
+    $this->state = $state;
+    $this->fastlyApi = $fastlyApi;
+  }
+
+  /**
+   * Used to validate API token for purge related scope.
+   *
+   * @return bool
+   *   TRUE if API token is capable of necessary purge actions, FALSE otherwise.
+   */
+  public function validatePurgeCredentials($apiKey = '') {
+    if (empty($apiKey)) {
+      return FALSE;
+    }
+    $this->fastlyApi->setApiKey($apiKey);
+    return $this->fastlyApi->validateApiKey();
+  }
+
+  /**
+   * Get the Drupal state representing whether or not the configured Fastly Api
+   * credentials are sufficient to perform all supported types of purge requests.
+   *
+   * @return mixed
+   */
+  public function getPurgeCredentialsState() {
+    $state = $this->state->get(self::VALID_PURGE_CREDENTIALS);
+    return $state;
+  }
+
+  /**
+   * Get the Drupal state representing whether or not the configured Fastly Api
+   * credentials are sufficient to perform all supported types of purge requests.
+   */
+  public function setPurgeCredentialsState($state = FALSE) {
+    $this->state->set(self::VALID_PURGE_CREDENTIALS, $state);
+  }
+
+}

--- a/src/State.php
+++ b/src/State.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\fastly;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\State\StateInterface;
 
 /**
@@ -13,53 +12,18 @@ class State {
   const VALID_PURGE_CREDENTIALS = 'fastly.state.valid_purge_credentials';
 
   /**
-   * @var \Drupal\Core\Config\Config
-   */
-  protected $config;
-
-  /**
    * @var \Drupal\Core\State\StateInterface
    */
   protected $state;
 
   /**
-   * @var \Drupal\fastly\Api
-   */
-  protected $fastlyApi;
-
-  /**
-   * @var bool
-   */
-  protected $validPurgeCredentials;
-
-  /**
    * ValidateCredentials constructor.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
-   *   Fastly config object.
    * @param \Drupal\Core\State\StateInterface $state
    *   The drupal state service.
-   * @param \Drupal\fastly\Api $fastlyApi
-   *   Fastly API for Drupal.
    */
-  public function __construct(ConfigFactoryInterface $config, StateInterface $state, Api $fastlyApi) {
-    $this->config = $config->get('fastly.settings');
+  public function __construct(StateInterface $state) {
     $this->state = $state;
-    $this->fastlyApi = $fastlyApi;
-  }
-
-  /**
-   * Used to validate API token for purge related scope.
-   *
-   * @return bool
-   *   TRUE if API token is capable of necessary purge actions, FALSE otherwise.
-   */
-  public function validatePurgeCredentials($apiKey = '') {
-    if (empty($apiKey)) {
-      return FALSE;
-    }
-    $this->fastlyApi->setApiKey($apiKey);
-    return $this->fastlyApi->validateApiKey();
   }
 
   /**


### PR DESCRIPTION
### Update `fastly` module.

- Add new config property to to fastly module to track is purge credentials are valid and write update hook.
- Add to fastly module support for API tokens
- Add to fastly module a hook_requirements and hook_help.
- Add drush command to purge a single URL and fix other drush commands to work with keys.
- Update Api class to support purgeUrl
- Cleanup code style and grammar


### Create `fastly_purger` module.

- Override/disable `fastly.cache_tags.invalidator` so only one purge solution fires
- Create a DiagnosticCheck to verify creds are valid
- Create Purger plugin